### PR TITLE
fixed forum url typo

### DIFF
--- a/data/pages/en/start.txt
+++ b/data/pages/en/start.txt
@@ -2,7 +2,7 @@
 {{keywords>marketing, email, invoice, support, tickets, sales}}
 <WRAP center round box hi 80%><wrap center 90%>**__Welcome to the coreBOS Documentation Site__**</wrap>
 <wrap center 90% em>[[http://corebos.org|Proud member of the coreBOS family!]]</wrap>
-<wrap center 90% em>Visit our [[http://corebos.org|Website]] and Follow us on [[https://plus.google.com/communities/109845486286232591652|Google+]] and [[http://discussion.corebos.org|the forum]]</wrap></WRAP>
+<wrap center 90% em>Visit our [[http://corebos.org|Website]] and Follow us on [[https://plus.google.com/communities/109845486286232591652|Google+]] and [[http://discussions.corebos.org|the forum]]</wrap></WRAP>
 <menu col=1,align=left>
   <item>Install and Update|How to install and update the application|installupdate|{{menu:software-icon_32.png?direct|}}</item>
   <item>User Manual|How to use the application|usermanual|{{menu:little_knight_32.png?direct|}}</item>


### PR DESCRIPTION
Was just browsing your docs and noticed that the link to the forums on the home page was broken. Obviously just a typo :smile: 

PS, not sure why ln 14 is showing as edited, I didn't touch that, but I did just do it in the GH ui...?!
